### PR TITLE
feature: monkeypatch httpx to have longer timeout

### DIFF
--- a/graphpyshop/__main__.py
+++ b/graphpyshop/__main__.py
@@ -1,7 +1,10 @@
 import argparse
-import logging
+import functools
+import logging.config
 import os
 import shutil
+import time
+from functools import lru_cache
 
 from ariadne_codegen.config import get_client_settings, get_config_dict
 from dotenv import find_dotenv, load_dotenv
@@ -9,13 +12,59 @@ from dotenv import find_dotenv, load_dotenv
 logging.basicConfig(level=logging.INFO)
 
 
+class TimedLog:
+    def __init__(self, name: str):
+        self.name = name
+
+    def __enter__(self):
+        self.start = time.time()
+
+    def __exit__(self, *args):
+        duration = (time.time() - self.start) * 1000
+        logging.info(f"{self.name} took {duration:.1f} ms")
+
+
+@lru_cache
+def monkey_patch_httpx():
+    """Wrap all the httpx functions to have a default timeout of 30 (get, post, etc)"""
+    import httpx
+    from httpx import Timeout
+
+    new_timeout = Timeout(90)
+
+    original_get = httpx.get
+
+    @functools.wraps(httpx.get)
+    def get(*args, **kwargs):
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = new_timeout
+        return original_get(*args, **kwargs)
+
+    httpx.get = get
+
+    original_post = httpx.post
+
+    @functools.wraps(httpx.post)
+    def post(*args, **kwargs):
+        if "timeout" not in kwargs:
+            kwargs["timeout"] = new_timeout
+        return original_post(*args, **kwargs)
+
+    httpx.post = post
+
+
 def generate_client():
+    monkey_patch_httpx()
+
     from ariadne_codegen.main import client
 
     logging.info("Starting generation of client")
 
     load_dotenv(find_dotenv())
-    client(get_config_dict())
+    config_dict = get_config_dict()
+    print(config_dict)
+    with TimedLog("Client generation"):
+        client(config_dict)
 
 
 def generate_queries():
@@ -58,6 +107,25 @@ def clean():
                 shutil.rmtree(path)
 
 
+def configure_logging():
+    log_config = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "formatters": {
+            "standard": {"format": "%(asctime)s [%(levelname)s] %(name)s: %(message)s"}
+        },
+        "handlers": {
+            "default": {
+                "level": "INFO",
+                "formatter": "standard",
+                "class": "logging.StreamHandler",
+            }
+        },
+        "loggers": {"": {"handlers": ["default"], "level": "INFO", "propagate": True}},
+    }
+    logging.config.dictConfig(log_config)
+
+
 def main():
     parser = argparse.ArgumentParser(description="GraphPyShop CLI")
     parser.add_argument(
@@ -66,13 +134,15 @@ def main():
         help="Command to run",
     )
     args = parser.parse_args()
-
-    if args.command == "generate-client":
-        generate_client()
-    elif args.command == "generate-queries":
-        generate_queries()
-    elif args.command == "clean":
-        clean()
+    configure_logging()
+    monkey_patch_httpx()
+    with TimedLog(f"Command {args.command}"):
+        if args.command == "generate-client":
+            generate_client()
+        elif args.command == "generate-queries":
+            generate_queries()
+        elif args.command == "clean":
+            clean()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### **PR Type**
Enhancement, Other


___

### **Description**
- Introduced a `TimedLog` class to log the execution time of code blocks.
- Added a `monkey_patch_httpx` function to set a default timeout of 90 seconds for `httpx` requests.
- Implemented a `configure_logging` function to set up a standardized logging configuration.
- Enhanced the `main` function to include logging configuration and timing for commands.
- Updated `generate_client` function to include HTTPX monkey patching and execution timing.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__main__.py</strong><dd><code>Add logging, HTTPX timeout monkey patch, and execution timing</code></dd></summary>
<hr>
      
graphpyshop/__main__.py

<li>Added <code>TimedLog</code> class for logging execution time of code blocks.<br> <li> Introduced <code>monkey_patch_httpx</code> function to set a default timeout for <br><code>httpx</code> requests.<br> <li> Implemented <code>configure_logging</code> function to set up logging <br>configuration.<br> <li> Enhanced <code>main</code> function to include logging configuration and timing for <br>commands.<br>


</details>
    

  </td>
  <td><a href="https://github.com/yummyshop/GraphPyShop/pull/3/files#diff-911414d8ec9f13df0d5eb0766f89a76b425330d90a667c72c5931a73e93b0ef4">+79/-9</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

